### PR TITLE
Update for FAIR

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: CorpusScraper
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Julian
+    family-names: Gonggrijp
+    affiliation: Utrecht University
+    orcid: 'https://orcid.org/0000-0002-2744-5160'
+repository-code: 'https://github.com/CentreForDigitalHumanities/corpus-scraper'
+url: 'https://centrefordigitalhumanities.github.io/corpus-scraper/'
+abstract: >-
+  CorpusScraper is a small script that you can run from your
+  bookmarks bar (a “bookmarklet”). It extracts data from an
+  online text corpus and lets you save the data to a CSV
+  file, in just a few clicks.
+keywords:
+  - web scraping
+  - corpus
+  - bookmarklet
+license: MIT

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 CorpusScraper
 =============
 
-By Digital Humanities Lab, Utrecht University
+By [Research Software Lab](https://cdh.uu.nl/about/research-software-lab/), Centre for Digital Humanities, Utrecht University
 
 
 Motivation
@@ -9,7 +9,7 @@ Motivation
 
 Some online text concordance corpora, such as Corpus del Español, do not offer a button to download your search results in a practical format, effectively expecting you to copy, paste and edit the data manually page by page. CorpusScraper is a bookmarklet that automates that work for you, so saving your search results becomes nearly as easy as if there would be such a button.
 
-See https://uudigitalhumanitieslab.github.io/corpus-scraper/ for a full explanation of the usage.
+See https://centrefordigitalhumanities.github.io/corpus-scraper/ for a full explanation of the usage.
 
 
 What’s included

--- a/corpusScraper.js
+++ b/corpusScraper.js
@@ -137,6 +137,7 @@
 					return 'number';
 				case 'A\xD1O':
 					return 'date';
+				case 'TÍTULO':
 				case 'T\xCDTULO':
 					return 'text';
 				case 'CONCORDANCIA':


### PR DESCRIPTION
Update for FAIR, new location, small bugfix.

The bookmarklet still works (can modify the bookmarklet to use jsdelivr to try: `javascript:(function(){var scriptnode = document.createElement('script');scriptnode.setAttribute('src', '//cdn.jsdelivr.net/gh/CentreForDigitalHumanities/corpus-scraper@feature/fair/corpusScraper.js');document.head.appendChild(scriptnode);}())`).

After merge I'll create a new release (2.1 I guess?) for Zenodo, then update gh-pages branch separately.